### PR TITLE
Import gcc_current_sp from nrfx 2.10.0

### DIFF
--- a/modules/nrfx/mdk/compiler_abstraction.h
+++ b/modules/nrfx/mdk/compiler_abstraction.h
@@ -143,8 +143,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     static inline unsigned int gcc_current_sp(void)
     {
-        register unsigned sp __ASM("sp");
-        return sp;
+        unsigned int stack_pointer = 0;
+        __asm__ __volatile__ ("mov %0, sp" : "=r"(stack_pointer));
+        return stack_pointer;
     }
 
 #elif defined   ( __TASKING__ )


### PR DESCRIPTION
This fixes a Clang warning about uninitialized
sp.